### PR TITLE
fix: avoid create_migration method conflict

### DIFF
--- a/lib/generators/simple_captcha_generator.rb
+++ b/lib/generators/simple_captcha_generator.rb
@@ -6,17 +6,20 @@ class SimpleCaptchaGenerator < Rails::Generators::Base
   def self.source_root
     @source_root ||= File.expand_path(File.join(File.dirname(__FILE__), 'templates/'))
   end
-  
+
   def create_partial
     template "partial.erb", File.join('app/views', 'simple_captcha', "_simple_captcha.erb")
   end
 
   unless defined?(Mongoid)
+
     def self.next_migration_number(dirname)
       Time.now.strftime("%Y%m%d%H%M%S")
     end
-    def create_migration
+
+    def create_captcha_migration
       migration_template "migration.rb", File.join('db/migrate', "create_simple_captcha_data.rb")
     end
+
   end
 end


### PR DESCRIPTION
rails4 run `rails g simple_captcha` throws error:

```
/usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/bundler/gems/simple-captcha-e0fc6ae2d155/lib/generators/simple_captcha_generator.rb:18:in `create_migration': wrong number of arguments (3 for 0) (ArgumentError)
    from /usr/local/var/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/railties-4.1.5/lib/rails/generators/migration.rb:63:in `migration_template'
```

because of method conflict
see https://github.com/pludoni/simple-captcha/commit/f0677ed6c11c9fdabe58031a7249b3645e4ba221
